### PR TITLE
Sources: Remove duplicate row, fix typos

### DIFF
--- a/sources/README.md
+++ b/sources/README.md
@@ -9,11 +9,10 @@ One of the developer tools most powerful features is the sources tab. This secti
 |:-------------------------:| ---------------------------------------------------------------------------- |
 | `ctrl` + `O`              | Search scripts and stylesheets by filename*                                  |
 | `ctrl` + `F`              | Search text within the current file                                          |
-| `ctrl` + `shift` + `F`    | Search text accross all files                                                |
-| `ctrl` + `shift` + `O`    | Navigate to a JavaScript function/method or CSS rule within the current file |
 | `ctrl` + `shift` + `F`    | Search text accross all files*                                               |
+| `ctrl` + `shift` + `O`    | Navigate to a JavaScript function/method or CSS rule within the current file |
 | `ctrl` + `G`              | Navigate to line number within current file                                  |
 | `alt` + `-` & `alt` + `+` | Navigate through source code editing locations - `+` is forward and `-` back |
-| `ctrl` + `D` | Multi-select find next occurance |
-| `ctrl` + `U` | Undo last multi-select occurance |
+| `ctrl` + `D`              | Multi-select find next occurence                                             |
+| `ctrl` + `U`              | Undo last multi-select occurence                                             |
 \* Available in all tabs (network, sources, elements, etc)


### PR DESCRIPTION
- Removed duplicate Ctrl + Shift + O listing
- "occurrance" -> "occurrence"
- Apply consistent spacing to table.